### PR TITLE
Fix logo and tours vanishing

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -42,7 +42,7 @@ $(window).load(function() {
 // End-top-nav-script
 
 // change icon, when window is being resized
-$(document).ready(function(){
+var ready = function(){
   // smooth scrolling
   $(".scroll").click(function(event){
     event.preventDefault();
@@ -73,9 +73,10 @@ $(document).ready(function(){
   $(window).resize(logoResize);
 
   // swipebox function
-  $( '.swipebox' ).swipebox();
+  $('.swipebox').swipebox();
+}
 
-})
+$(document).on('turbolinks:load', ready);
 
 function findMarker(i){
   console.log(Gmaps.store.markers.length);


### PR DESCRIPTION
Fix for #16. 

The error started when upgrating turbolinks gem to 5.0. The `$(document).ready` was not triggered anymore by a page reload, instead we have to listen to the evend `turbolinks:load`. 

Also see [this](https://github.com/turbolinks/turbolinks/issues/4).